### PR TITLE
Fix Newsblurry::Agent initialization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ And then:
 Create a new agent with your username and password.
 Use the agent to retrieve your unread stories or mark a story as read.
 
-    agent = Newsblurry::Agent(username, password)
+    agent = Newsblurry::Agent.new(username, password)
 
 ### Return all unread stories for account
     unread_stories = agent.unread_stories


### PR DESCRIPTION
When I followed the existing agent initialization code in the README it gave me a ``NoMethodError: undefined method `Agent' for Newsblurry:Module`` error.  I figured this was meant to be `Newsblurry::Agent.new()`, so here we are.