### PR TITLE
Remove treat_symbols_as_metadata_keys_with_true_values config

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,5 @@ require 'webmock/rspec'
 WebMock.disable_net_connect!
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
I'm working on some small modifications and RSpec was giving the following deprecation warning.

```
RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= is deprecated, it is now set to true as default and setting it to false has no effect.
```

`config.treat_symbols_as_metadata_keys_with_true_values` was set to true in `spec_helper.rb`, so we can simply remove this statement to quiet the warning.