### PR TITLE
Allow for story content to be optionally fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use the agent to retrieve your unread stories or mark a story as read.
 ### Return all unread stories for account
     unread_stories = agent.unread_stories
 
-By default, `Agent.unread_stories` does not fetch the story content. However, you can provide a boolean argument to determine whether the story_content should be fetched. To fetch the story content as well, simply pass `true` to `unread_stories`.
+By default, `Agent.unread_stories` does not fetch the story content. However, you can provide a boolean argument to determine whether the story content should be fetched. To fetch the story content as well, simply pass `true` to `unread_stories`.
 
     unread_stories = agent.unread_stories(true)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use the agent to retrieve your unread stories or mark a story as read.
 ### Return all unread stories for account
     unread_stories = agent.unread_stories
 
-By default, `Agent.unread_stories` does not fetch the story content but you can override this by setting the `include_story_content` option to `true`.
+`Agent.unread_stories` does not fetch the story content by default but you can override this by setting the `include_story_content` option to `true`.
 
     unread_stories = agent.unread_stories(include_story_content: true)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use the agent to retrieve your unread stories or mark a story as read.
 ### Return all unread stories for account
     unread_stories = agent.unread_stories
 
-`Agent.unread_stories` can also take a boolean argument which determines whether the story_content should be fetched.
+By default, `Agent.unread_stories` does not fetch the story content. However, you can provide a boolean argument to determine whether the story_content should be fetched. To fetch the story content as well, simply pass `true` to `unread_stories`.
 
     unread_stories = agent.unread_stories(true)
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Use the agent to retrieve your unread stories or mark a story as read.
 ### Return all unread stories for account
     unread_stories = agent.unread_stories
 
-By default, `Agent.unread_stories` does not fetch the story content. However, you can provide a boolean argument to determine whether the story content should be fetched. To fetch the story content as well, simply pass `true` to `unread_stories`.
+By default, `Agent.unread_stories` does not fetch the story content but you can override this by setting the `include_story_content` option to `true`.
 
-    unread_stories = agent.unread_stories(true)
+    unread_stories = agent.unread_stories(include_story_content: true)
 
 ### Mark a story as read
     agent.mark_as_read(newsblurry_story_hash)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Use the agent to retrieve your unread stories or mark a story as read.
 ### Return all unread stories for account
     unread_stories = agent.unread_stories
 
+`Agent.unread_stories` can also take a boolean argument which determines whether the story_content should be fetched.
+
+    unread_stories = agent.unread_stories(true)
+
 ### Mark a story as read
     agent.mark_as_read(newsblurry_story_hash)
 

--- a/lib/newsblurry/agent.rb
+++ b/lib/newsblurry/agent.rb
@@ -5,8 +5,8 @@ module Newsblurry
       @connection = Newsblurry::Connection.new(username, password)
     end
 
-    def unread_stories(include_story_content = false)
-      @connection.unread_stories(include_story_content)
+    def unread_stories(options = {})
+      @connection.unread_stories(options)
     end
 
     def mark_as_read(story_hash)

--- a/lib/newsblurry/agent.rb
+++ b/lib/newsblurry/agent.rb
@@ -5,8 +5,8 @@ module Newsblurry
       @connection = Newsblurry::Connection.new(username, password)
     end
 
-    def unread_stories
-      @connection.unread_stories
+    def unread_stories(include_story_content = false)
+      @connection.unread_stories(include_story_content)
     end
 
     def mark_as_read(story_hash)

--- a/lib/newsblurry/connection.rb
+++ b/lib/newsblurry/connection.rb
@@ -12,11 +12,11 @@ module Newsblurry
       @cookie = response.headers['set-cookie']
     end
 
-    def unread_stories(include_story_content = false)
+    def unread_stories(options = {})
       feed_array = feeds
       unread_feed_story_hashes.keys.flat_map do |feed_id|
         feed = feed_array.find { |f| f.id == feed_id.to_i }
-        unread_stories_for_feed(feed, include_story_content)
+        unread_stories_for_feed(feed, options)
       end
     end
 
@@ -32,11 +32,11 @@ module Newsblurry
       FeedParser.new(response['feeds']).feeds
     end
 
-    def unread_stories_for_feed(feed, include_story_content = false)
+    def unread_stories_for_feed(feed, options = {})
       options = {
         query: {
-          read_filter: 'unread', include_story_content: include_story_content
-        }
+          read_filter: 'unread', include_story_content: false
+        }.merge(options)
       }
       response = get_request("/reader/feed/#{feed.id}", options)
       StoryParser.new(feed, response['stories']).stories

--- a/lib/newsblurry/connection.rb
+++ b/lib/newsblurry/connection.rb
@@ -12,11 +12,11 @@ module Newsblurry
       @cookie = response.headers['set-cookie']
     end
 
-    def unread_stories
+    def unread_stories(include_story_content = false)
       feed_array = feeds
       unread_feed_story_hashes.keys.flat_map do |feed_id|
         feed = feed_array.find { |f| f.id == feed_id.to_i }
-        unread_stories_for_feed(feed)
+        unread_stories_for_feed(feed, include_story_content)
       end
     end
 
@@ -32,10 +32,10 @@ module Newsblurry
       FeedParser.new(response['feeds']).feeds
     end
 
-    def unread_stories_for_feed(feed)
+    def unread_stories_for_feed(feed, include_story_content = false)
       options = {
         query: {
-          read_filter: 'unread', include_story_content: false
+          read_filter: 'unread', include_story_content: include_story_content
         }
       }
       response = get_request("/reader/feed/#{feed.id}", options)

--- a/lib/newsblurry/story.rb
+++ b/lib/newsblurry/story.rb
@@ -1,7 +1,7 @@
 module Newsblurry
   class Story
 
-    attr_reader :title, :link, :authors, :hash, :published_at, :tags,
+    attr_reader :title, :link, :authors, :hash, :published_at, :tags, :content,
                 :feed_title, :feed_link, :feed_address
 
     def initialize(feed, story_hash)
@@ -11,6 +11,7 @@ module Newsblurry
       @hash = story_hash['story_hash']
       @published_at = DateTime.parse(story_hash['story_date'])
       @tags = story_hash['story_tags']
+      @content = story_hash['story_content']
       @feed_title = feed.title
       @feed_link = feed.link
       @feed_address = feed.address

--- a/spec/newsblurry/story_spec.rb
+++ b/spec/newsblurry/story_spec.rb
@@ -8,7 +8,11 @@ describe Newsblurry::Story do
       'story_authors' => 'The Big Picture',
       'story_hash' => '1095:67324d',
       'story_date' => '2013-10-07 23:54:16',
-      'story_tags' => ['Fukushima', 'Japan', 'tsunami']
+      'story_tags' => ['Fukushima', 'Japan', 'tsunami'],
+      'story_content' => 'In 2011 a massive earthquake and tsunami wrecked ' \
+                         'the Fukushima nuclear plant, resulting in a ' \
+                         'meltdown that became the world\'s worst atomic ' \
+                         'crisis in 25 years.'
     }
 
     feed_hash = {
@@ -50,6 +54,13 @@ describe Newsblurry::Story do
   it 'returns the tags' do
     tags = ['Fukushima', 'Japan', 'tsunami']
     expect(@story.tags).to eq(tags)
+  end
+
+  it 'returns the content' do
+    content = 'In 2011 a massive earthquake and tsunami wrecked the ' \
+              'Fukushima nuclear plant, resulting in a meltdown that ' \
+              'became the world\'s worst atomic crisis in 25 years.'
+    expect(@story.content).to eq(content)
   end
 
   it 'returns the feed_title' do


### PR DESCRIPTION
This is a first crack at exposing the `include_story_content` option to users.  Currently it's hardcoded to false and there doesn't appear to be an easy way for users to override this if they so desire.

I simply added an `include_story_content` boolean parameter to `Agent.unread_stories`, `Connection.unread_stories`, and `Connection.unread_stories_for_feed`.  It defaults to false so that you can still use `Agent.unread_stories` with no arguments but if you use `Agent.unread_stories(true)` it will also include the story content (accessible at `Story.content`).

Let me know what you think and we can go from there.