### PR TITLE
Resolve existing Rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
-Documentation:
-  Enabled: false
 AllCops:
   Exclude:
     - vendor/**
     - spec/fixtures/**
+
+Documentation:
+  Enabled: false
+  
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 Documentation:
   Enabled: false
 AllCops:
-  Excludes:
+  Exclude:
     - vendor/**
     - spec/fixtures/**

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org/'
 
 gemspec
 
-gem "pry"
-gem "rspec"
-gem "rake"
+gem 'pry'
+gem 'rspec'
+gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source 'https://rubygems.org/'
+source "https://rubygems.org/"
 
 gemspec
 
-gem 'pry'
-gem 'rspec'
-gem 'rake'
+gem "pry"
+gem "rspec"
+gem "rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,22 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-task :default => :spec
+task default: :spec
 
 def bundle_exec(command)
-  sh %Q{bundle update && bundle exec #{command}}
+  sh %(bundle update && bundle exec #{command})
 end
 
 def bundle_install_dependencies
-  sh %Q{bundle install --path vendor/bundle}
+  sh %(bundle install --path vendor/bundle)
 end
 
-desc "Run all specs"
-task "spec" do
-  bundle_exec("rspec spec")
+desc 'Run all specs'
+task 'spec' do
+  bundle_exec('rspec spec')
 end
 
-desc "Install dependencies"
-task "dependencies" do
+desc 'Install dependencies'
+task 'dependencies' do
   bundle_install_dependencies
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'bundler'
+require "bundler"
 Bundler::GemHelper.install_tasks
 
 task default: :spec
@@ -11,12 +11,12 @@ def bundle_install_dependencies
   sh %(bundle install --path vendor/bundle)
 end
 
-desc 'Run all specs'
-task 'spec' do
-  bundle_exec('rspec spec')
+desc "Run all specs"
+task "spec" do
+  bundle_exec("rspec spec")
 end
 
-desc 'Install dependencies'
-task 'dependencies' do
+desc "Install dependencies"
+task "dependencies" do
   bundle_install_dependencies
 end

--- a/lib/newsblurry.rb
+++ b/lib/newsblurry.rb
@@ -1,11 +1,11 @@
-require 'httparty'
-require 'newsblurry/version'
+require "httparty"
+require "newsblurry/version"
 
 module Newsblurry
-  autoload :Agent, 'newsblurry/agent'
-  autoload :Connection, 'newsblurry/connection'
-  autoload :Feed, 'newsblurry/feed'
-  autoload :FeedParser, 'newsblurry/feed_parser'
-  autoload :Story, 'newsblurry/story'
-  autoload :StoryParser, 'newsblurry/story_parser'
+  autoload :Agent, "newsblurry/agent"
+  autoload :Connection, "newsblurry/connection"
+  autoload :Feed, "newsblurry/feed"
+  autoload :FeedParser, "newsblurry/feed_parser"
+  autoload :Story, "newsblurry/story"
+  autoload :StoryParser, "newsblurry/story_parser"
 end

--- a/lib/newsblurry/agent.rb
+++ b/lib/newsblurry/agent.rb
@@ -1,6 +1,5 @@
 module Newsblurry
   class Agent
-
     def initialize(username, password)
       @connection = Newsblurry::Connection.new(username, password)
     end

--- a/lib/newsblurry/connection.rb
+++ b/lib/newsblurry/connection.rb
@@ -1,15 +1,15 @@
 module Newsblurry
   class Connection
     include HTTParty
-    base_uri 'https://www.newsblur.com'
+    base_uri "https://www.newsblur.com"
     disable_rails_query_string_format
 
     debug_output
 
     def initialize(username, password)
       options = { body: { username: username, password: password } }
-      response = post_request('/api/login', options)
-      @cookie = response.headers['set-cookie']
+      response = post_request("/api/login", options)
+      @cookie = response.headers["set-cookie"]
     end
 
     def unread_stories(options = {})
@@ -22,29 +22,29 @@ module Newsblurry
 
     def mark_as_read(story_hash)
       options = { body: { story_hash: story_hash } }
-      post_request('/reader/mark_story_hashes_as_read', options)
+      post_request("/reader/mark_story_hashes_as_read", options)
     end
 
     private
 
     def feeds
-      response = get_request('/reader/feeds')
-      FeedParser.new(response['feeds']).feeds
+      response = get_request("/reader/feeds")
+      FeedParser.new(response["feeds"]).feeds
     end
 
     def unread_stories_for_feed(feed, options = {})
       options = {
         query: {
-          read_filter: 'unread', include_story_content: false
+          read_filter: "unread", include_story_content: false
         }.merge(options)
       }
       response = get_request("/reader/feed/#{feed.id}", options)
-      StoryParser.new(feed, response['stories']).stories
+      StoryParser.new(feed, response["stories"]).stories
     end
 
     def unread_feed_story_hashes
-      response = get_request('/reader/unread_story_hashes')
-      response['unread_feed_story_hashes']
+      response = get_request("/reader/unread_story_hashes")
+      response["unread_feed_story_hashes"]
     end
 
     def get_request(url, options = {})
@@ -59,8 +59,8 @@ module Newsblurry
 
     def headers
       { headers: {
-        'User-Agent' => "#{self.class.name} - #{Newsblurry::VERSION}",
-        'Cookie' => @cookie || '' }
+        "User-Agent" => "#{self.class.name} - #{Newsblurry::VERSION}",
+        "Cookie" => @cookie || "" }
       }
     end
   end

--- a/lib/newsblurry/feed.rb
+++ b/lib/newsblurry/feed.rb
@@ -3,10 +3,10 @@ module Newsblurry
     attr_reader :id, :title, :link, :address
 
     def initialize(feed_hash)
-      @id = feed_hash['id']
-      @title = feed_hash['feed_title']
-      @link = feed_hash['feed_link']
-      @address = feed_hash['feed_address']
+      @id = feed_hash["id"]
+      @title = feed_hash["feed_title"]
+      @link = feed_hash["feed_link"]
+      @address = feed_hash["feed_address"]
     end
   end
 end

--- a/lib/newsblurry/feed_parser.rb
+++ b/lib/newsblurry/feed_parser.rb
@@ -1,6 +1,5 @@
 module Newsblurry
   class FeedParser
-
     attr_reader :feeds
 
     def initialize(feeds_hash)

--- a/lib/newsblurry/story.rb
+++ b/lib/newsblurry/story.rb
@@ -4,13 +4,13 @@ module Newsblurry
                 :feed_title, :feed_link, :feed_address
 
     def initialize(feed, story_hash)
-      @title = story_hash['story_title']
-      @link = story_hash['story_permalink']
-      @authors = story_hash['story_authors']
-      @hash = story_hash['story_hash']
-      @published_at = DateTime.parse(story_hash['story_date'])
-      @tags = story_hash['story_tags']
-      @content = story_hash['story_content']
+      @title = story_hash["story_title"]
+      @link = story_hash["story_permalink"]
+      @authors = story_hash["story_authors"]
+      @hash = story_hash["story_hash"]
+      @published_at = DateTime.parse(story_hash["story_date"])
+      @tags = story_hash["story_tags"]
+      @content = story_hash["story_content"]
       @feed_title = feed.title
       @feed_link = feed.link
       @feed_address = feed.address

--- a/lib/newsblurry/story.rb
+++ b/lib/newsblurry/story.rb
@@ -1,6 +1,5 @@
 module Newsblurry
   class Story
-
     attr_reader :title, :link, :authors, :hash, :published_at, :tags, :content,
                 :feed_title, :feed_link, :feed_address
 

--- a/lib/newsblurry/story_parser.rb
+++ b/lib/newsblurry/story_parser.rb
@@ -1,6 +1,5 @@
 module Newsblurry
   class StoryParser
-
     attr_reader :stories
 
     def initialize(feed, story_hashes)

--- a/lib/newsblurry/version.rb
+++ b/lib/newsblurry/version.rb
@@ -1,3 +1,3 @@
 module Newsblurry
-  VERSION = '1.0.0'
+  VERSION = "1.0.0"
 end

--- a/newsblurry.gemspec
+++ b/newsblurry.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "newsblurry/version"
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+require 'newsblurry/version'
 
 Gem::Specification.new do |s|
   s.name    = 'newsblurry'
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.summary     = 'Newsblurry is a Ruby client for the Newsblur API.'
   s.description = 'Access your Newsblur feed using Ruby.'
-  s.licenses    = ["MIT"]
+  s.licenses    = ['MIT']
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")

--- a/newsblurry.gemspec
+++ b/newsblurry.gemspec
@@ -1,26 +1,26 @@
 # -*- encoding: utf-8 -*-
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
-require 'newsblurry/version'
+$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+require "newsblurry/version"
 
 Gem::Specification.new do |s|
-  s.name    = 'newsblurry'
+  s.name    = "newsblurry"
   s.version = Newsblurry::VERSION
   s.platform = Gem::Platform::RUBY
 
-  s.authors  = ['Joey Geiger']
-  s.email    = 'jgeiger@gmail.com'
-  s.homepage = 'http://github.com/jgeiger/newsblurry'
+  s.authors  = ["Joey Geiger"]
+  s.email    = "jgeiger@gmail.com"
+  s.homepage = "http://github.com/jgeiger/newsblurry"
 
-  s.summary     = 'Newsblurry is a Ruby client for the Newsblur API.'
-  s.description = 'Access your Newsblur feed using Ruby.'
-  s.licenses    = ['MIT']
+  s.summary     = "Newsblurry is a Ruby client for the Newsblur API."
+  s.description = "Access your Newsblur feed using Ruby."
+  s.licenses    = ["MIT"]
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")
-  s.require_paths = ['lib']
+  s.require_paths = ["lib"]
 
-  s.add_dependency 'httparty'
+  s.add_dependency "httparty"
 
-  s.add_development_dependency 'webmock'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency "webmock"
+  s.add_development_dependency "pry"
 end

--- a/spec/newsblurry/agent_spec.rb
+++ b/spec/newsblurry/agent_spec.rb
@@ -7,7 +7,7 @@ describe Newsblurry::Agent do
     @connection = double(:connection)
 
     expect(Newsblurry::Connection).to receive(:new)
-    .and_return(@connection)
+      .and_return(@connection)
 
     @agent = Newsblurry::Agent.new(username, password)
   end
@@ -32,7 +32,7 @@ describe Newsblurry::Agent do
         story_hash = '1234:abcd'
 
         expect(@connection).to receive(:mark_as_read)
-        .with(story_hash)
+          .with(story_hash)
 
         @agent.mark_as_read(story_hash)
       end

--- a/spec/newsblurry/agent_spec.rb
+++ b/spec/newsblurry/agent_spec.rb
@@ -1,9 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Newsblurry::Agent do
   before do
-    username = 'test'
-    password = 'test'
+    username = "test"
+    password = "test"
     @connection = double(:connection)
 
     expect(Newsblurry::Connection).to receive(:new)
@@ -12,24 +12,24 @@ describe Newsblurry::Agent do
     @agent = Newsblurry::Agent.new(username, password)
   end
 
-  context '#initialize' do
-    it 'creates a Newsblurry::Agent instance' do
+  context "#initialize" do
+    it "creates a Newsblurry::Agent instance" do
       expect(@agent.class).to eq(Newsblurry::Agent)
     end
   end
 
-  context 'when accessing the API' do
-    context '#unread_stories' do
-      it 'calls the connection method for unread_stories' do
+  context "when accessing the API" do
+    context "#unread_stories" do
+      it "calls the connection method for unread_stories" do
         expect(@connection).to receive(:unread_stories)
 
         @agent.unread_stories
       end
     end
 
-    context '#mark_as_read' do
-      it 'calls the connection method for mark_as_read' do
-        story_hash = '1234:abcd'
+    context "#mark_as_read" do
+      it "calls the connection method for mark_as_read" do
+        story_hash = "1234:abcd"
 
         expect(@connection).to receive(:mark_as_read)
           .with(story_hash)

--- a/spec/newsblurry/connection_spec.rb
+++ b/spec/newsblurry/connection_spec.rb
@@ -1,17 +1,17 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Newsblurry::Connection do
-  context '#initialize' do
-    it 'logs the user in' do
-      username = 'test'
-      password = 'test'
+  context "#initialize" do
+    it "logs the user in" do
+      username = "test"
+      password = "test"
 
-      stub_request(:post, 'https://www.newsblur.com/api/login')
+      stub_request(:post, "https://www.newsblur.com/api/login")
         .with(
-          body: 'password=test&username=test',
+          body: "password=test&username=test",
           headers: {
-            'Cookie' => '',
-            'User-Agent' => "Newsblurry::Connection - #{Newsblurry::VERSION}"
+            "Cookie" => "",
+            "User-Agent" => "Newsblurry::Connection - #{Newsblurry::VERSION}"
           }
         )
 
@@ -20,48 +20,48 @@ describe Newsblurry::Connection do
     end
   end
 
-  context 'when accessing the API' do
+  context "when accessing the API" do
     before do
-      stub_request(:post, 'https://www.newsblur.com/api/login')
-      @connection = Newsblurry::Connection.new('test', 'test')
+      stub_request(:post, "https://www.newsblur.com/api/login")
+      @connection = Newsblurry::Connection.new("test", "test")
     end
 
-    context '#unread_stories' do
-      it 'returns an array of unread Newsblurry::Story' do
-        feeds_file = File.new('spec/fixtures/feeds.txt')
-        stub_request(:get, 'https://www.newsblur.com/reader/feeds')
+    context "#unread_stories" do
+      it "returns an array of unread Newsblurry::Story" do
+        feeds_file = File.new("spec/fixtures/feeds.txt")
+        stub_request(:get, "https://www.newsblur.com/reader/feeds")
           .to_return(feeds_file)
 
-        hashes_file = File.new('spec/fixtures/unread_feed_story_hashes.txt')
+        hashes_file = File.new("spec/fixtures/unread_feed_story_hashes.txt")
         stub_request(
           :get,
-          'https://www.newsblur.com/reader/unread_story_hashes'
+          "https://www.newsblur.com/reader/unread_story_hashes"
         ).to_return(hashes_file)
 
-        feed_file = File.new('spec/fixtures/feed_1641.txt')
-        stub_request(:get, 'https://www.newsblur.com/reader/feed/1641')
-          .with(query: { include_story_content: false, read_filter: 'unread' })
+        feed_file = File.new("spec/fixtures/feed_1641.txt")
+        stub_request(:get, "https://www.newsblur.com/reader/feed/1641")
+          .with(query: { include_story_content: false, read_filter: "unread" })
           .to_return(feed_file)
 
         unread_stories = @connection.unread_stories
 
-        titles = ['Use Rails with the db schema you always wanted']
+        titles = ["Use Rails with the db schema you always wanted"]
         expect(unread_stories.map(&:title)).to match_array(titles)
       end
     end
 
-    context '#mark_as_read' do
-      it 'marks the Newsblurry::Story as read' do
-        file = File.new('spec/fixtures/mark_as_read_1095_cdeec3.txt')
+    context "#mark_as_read" do
+      it "marks the Newsblurry::Story as read" do
+        file = File.new("spec/fixtures/mark_as_read_1095_cdeec3.txt")
         stub_request(
           :post,
-          'https://www.newsblur.com/reader/mark_story_hashes_as_read'
-        ).with(body: 'story_hash=1095%3Acdeec3').to_return(file)
+          "https://www.newsblur.com/reader/mark_story_hashes_as_read"
+        ).with(body: "story_hash=1095%3Acdeec3").to_return(file)
 
-        story_hash_string = '1095:cdeec3'
+        story_hash_string = "1095:cdeec3"
         response = @connection.mark_as_read(story_hash_string)
 
-        expect(response['feed_ids']).to eq(['1095'])
+        expect(response["feed_ids"]).to eq(["1095"])
       end
     end
   end

--- a/spec/newsblurry/connection_spec.rb
+++ b/spec/newsblurry/connection_spec.rb
@@ -7,13 +7,13 @@ describe Newsblurry::Connection do
       password = 'test'
 
       stub_request(:post, 'https://www.newsblur.com/api/login')
-      .with(
-        body: 'password=test&username=test',
-        headers: {
-          'Cookie' => '',
-          'User-Agent' => "Newsblurry::Connection - #{Newsblurry::VERSION}",
-        }
-      )
+        .with(
+          body: 'password=test&username=test',
+          headers: {
+            'Cookie' => '',
+            'User-Agent' => "Newsblurry::Connection - #{Newsblurry::VERSION}"
+          }
+        )
 
       connection = Newsblurry::Connection.new(username, password)
       expect(connection.class).to eq(Newsblurry::Connection)
@@ -30,7 +30,7 @@ describe Newsblurry::Connection do
       it 'returns an array of unread Newsblurry::Story' do
         feeds_file = File.new('spec/fixtures/feeds.txt')
         stub_request(:get, 'https://www.newsblur.com/reader/feeds')
-        .to_return(feeds_file)
+          .to_return(feeds_file)
 
         hashes_file = File.new('spec/fixtures/unread_feed_story_hashes.txt')
         stub_request(
@@ -40,8 +40,8 @@ describe Newsblurry::Connection do
 
         feed_file = File.new('spec/fixtures/feed_1641.txt')
         stub_request(:get, 'https://www.newsblur.com/reader/feed/1641')
-        .with(query: { include_story_content: false, read_filter: 'unread' })
-        .to_return(feed_file)
+          .with(query: { include_story_content: false, read_filter: 'unread' })
+          .to_return(feed_file)
 
         unread_stories = @connection.unread_stories
 

--- a/spec/newsblurry/feed_parser_spec.rb
+++ b/spec/newsblurry/feed_parser_spec.rb
@@ -18,7 +18,7 @@ describe Newsblurry::FeedParser do
       'id' => 1641,
       'feed_link' => 'http://thechangelog.com',
       'feed_address' => 'http://feeds.feedburner.com/thechangelog',
-      'feed_title' => 'The Changelog',
+      'feed_title' => 'The Changelog'
     }
     feeds_hash = {
       '1084' =>  @ruby_feed_hash,

--- a/spec/newsblurry/feed_parser_spec.rb
+++ b/spec/newsblurry/feed_parser_spec.rb
@@ -1,34 +1,34 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Newsblurry::FeedParser do
   before do
     @ruby_feed_hash = {
-      'id' => 1084,
-      'feed_link' => 'http://www.rubyinside.com',
-      'feed_address' => 'http://feeds.feedburner.com/RubyInside',
-      'feed_title' => 'Ruby Inside'
+      "id" => 1084,
+      "feed_link" => "http://www.rubyinside.com",
+      "feed_address" => "http://feeds.feedburner.com/RubyInside",
+      "feed_title" => "Ruby Inside"
     }
     @pivotal_feed_hash = {
-      'id' => 588_670,
-      'feed_link' => 'http://pivotallabs.com',
-      'feed_address' => 'http://pivotallabs.com/feed/',
-      'feed_title' => 'Pivotal Labs'
+      "id" => 588_670,
+      "feed_link" => "http://pivotallabs.com",
+      "feed_address" => "http://pivotallabs.com/feed/",
+      "feed_title" => "Pivotal Labs"
     }
     @changelog_feed_hash = {
-      'id' => 1641,
-      'feed_link' => 'http://thechangelog.com',
-      'feed_address' => 'http://feeds.feedburner.com/thechangelog',
-      'feed_title' => 'The Changelog'
+      "id" => 1641,
+      "feed_link" => "http://thechangelog.com",
+      "feed_address" => "http://feeds.feedburner.com/thechangelog",
+      "feed_title" => "The Changelog"
     }
     feeds_hash = {
-      '1084' =>  @ruby_feed_hash,
-      '588670' =>  @pivotal_feed_hash,
-      '1641' =>  @changelog_feed_hash
+      "1084" =>  @ruby_feed_hash,
+      "588670" =>  @pivotal_feed_hash,
+      "1641" =>  @changelog_feed_hash
     }
     @feed_parser = Newsblurry::FeedParser.new(feeds_hash)
   end
 
-  it 'returns the feeds in an array' do
+  it "returns the feeds in an array" do
     ruby_feed = Newsblurry::Feed.new(@ruby_feed_hash)
     pivotal_feed = Newsblurry::Feed.new(@pivotal_feed_hash)
     changelog_feed = Newsblurry::Feed.new(@changelog_feed_hash)

--- a/spec/newsblurry/feed_spec.rb
+++ b/spec/newsblurry/feed_spec.rb
@@ -1,33 +1,33 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Newsblurry::Feed do
   before do
     feed_hash = {
-      'id' => 1084,
-      'feed_link' => 'http://www.rubyinside.com',
-      'feed_address' => 'http://feeds.feedburner.com/RubyInside',
-      'feed_title' => 'Ruby Inside'
+      "id" => 1084,
+      "feed_link" => "http://www.rubyinside.com",
+      "feed_address" => "http://feeds.feedburner.com/RubyInside",
+      "feed_title" => "Ruby Inside"
     }
     @feed = Newsblurry::Feed.new(feed_hash)
   end
 
-  it 'sets the id' do
+  it "sets the id" do
     id = 1084
     expect(@feed.id).to eq(id)
   end
 
-  it 'sets the link' do
-    link = 'http://www.rubyinside.com'
+  it "sets the link" do
+    link = "http://www.rubyinside.com"
     expect(@feed.link).to eq(link)
   end
 
-  it 'sets the title' do
-    title = 'Ruby Inside'
+  it "sets the title" do
+    title = "Ruby Inside"
     expect(@feed.title).to eq(title)
   end
 
-  it 'sets the address' do
-    address = 'http://feeds.feedburner.com/RubyInside'
+  it "sets the address" do
+    address = "http://feeds.feedburner.com/RubyInside"
     expect(@feed.address).to eq(address)
   end
 end

--- a/spec/newsblurry/story_parser_spec.rb
+++ b/spec/newsblurry/story_parser_spec.rb
@@ -1,29 +1,29 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Newsblurry::StoryParser do
   before do
     story_hashes = [
       {
-        'story_permalink' => 'http://feedproxy.google.com/~r/thechangelog/',
-        'story_hash' => '1641:aaae79',
-        'id' => 'http://thechangelog.com/?p=6697',
-        'story_date' => '2013-10-07 21:15:13',
-        'story_feed_id' => 1641,
-        'story_title' => 'Use Rails with the db schema you always wanted'
+        "story_permalink" => "http://feedproxy.google.com/~r/thechangelog/",
+        "story_hash" => "1641:aaae79",
+        "id" => "http://thechangelog.com/?p=6697",
+        "story_date" => "2013-10-07 21:15:13",
+        "story_feed_id" => 1641,
+        "story_title" => "Use Rails with the db schema you always wanted"
       }
     ]
     feed_hash = {
-      'id' => 1641,
-      'feed_link' => 'http://www.thechangelog.com',
-      'feed_address' => 'http://feeds.thechangelog.com',
-      'feed_title' => 'The Changelog'
+      "id" => 1641,
+      "feed_link" => "http://www.thechangelog.com",
+      "feed_address" => "http://feeds.thechangelog.com",
+      "feed_title" => "The Changelog"
     }
     feed = Newsblurry::Feed.new(feed_hash)
     @story_parser = Newsblurry::StoryParser.new(feed, story_hashes)
   end
 
-  it 'returns the stories in an array' do
-    parsed_title_array = ['Use Rails with the db schema you always wanted']
+  it "returns the stories in an array" do
+    parsed_title_array = ["Use Rails with the db schema you always wanted"]
     titles = @story_parser.stories.map(&:title)
     expect(titles).to match_array(parsed_title_array)
   end

--- a/spec/newsblurry/story_spec.rb
+++ b/spec/newsblurry/story_spec.rb
@@ -8,7 +8,7 @@ describe Newsblurry::Story do
       'story_authors' => 'The Big Picture',
       'story_hash' => '1095:67324d',
       'story_date' => '2013-10-07 23:54:16',
-      'story_tags' => ['Fukushima', 'Japan', 'tsunami'],
+      'story_tags' => %w('Fukushima', 'Japan', 'tsunami'),
       'story_content' => 'In 2011 a massive earthquake and tsunami wrecked ' \
                          'the Fukushima nuclear plant, resulting in a ' \
                          'meltdown that became the world\'s worst atomic ' \
@@ -52,7 +52,7 @@ describe Newsblurry::Story do
   end
 
   it 'returns the tags' do
-    tags = ['Fukushima', 'Japan', 'tsunami']
+    tags = %w('Fukushima', 'Japan', 'tsunami')
     expect(@story.tags).to eq(tags)
   end
 

--- a/spec/newsblurry/story_spec.rb
+++ b/spec/newsblurry/story_spec.rb
@@ -1,80 +1,80 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Newsblurry::Story do
   before do
     story_hash = {
-      'story_title' => 'Broken lives of Fukushima',
-      'story_permalink' => 'http://feeds.boston.com/c/35022/story01.htm',
-      'story_authors' => 'The Big Picture',
-      'story_hash' => '1095:67324d',
-      'story_date' => '2013-10-07 23:54:16',
-      'story_tags' => %w('Fukushima', 'Japan', 'tsunami'),
-      'story_content' => 'In 2011 a massive earthquake and tsunami wrecked ' \
-                         'the Fukushima nuclear plant, resulting in a ' \
-                         'meltdown that became the world\'s worst atomic ' \
-                         'crisis in 25 years.'
+      "story_title" => "Broken lives of Fukushima",
+      "story_permalink" => "http://feeds.boston.com/c/35022/story01.htm",
+      "story_authors" => "The Big Picture",
+      "story_hash" => "1095:67324d",
+      "story_date" => "2013-10-07 23:54:16",
+      "story_tags" => %w("Fukushima", "Japan", "tsunami"),
+      "story_content" => "In 2011 a massive earthquake and tsunami wrecked " \
+                         "the Fukushima nuclear plant, resulting in a " \
+                         "meltdown that became the world\"s worst atomic " \
+                         "crisis in 25 years."
     }
 
     feed_hash = {
-      'id' => 1095,
-      'feed_link' => 'http://boston.com',
-      'feed_address' => 'http://feeds.boston.com',
-      'feed_title' => 'The Big Picture'
+      "id" => 1095,
+      "feed_link" => "http://boston.com",
+      "feed_address" => "http://feeds.boston.com",
+      "feed_title" => "The Big Picture"
     }
 
     feed = Newsblurry::Feed.new(feed_hash)
     @story = Newsblurry::Story.new(feed, story_hash)
   end
 
-  it 'sets the link' do
-    link = 'http://feeds.boston.com/c/35022/story01.htm'
+  it "sets the link" do
+    link = "http://feeds.boston.com/c/35022/story01.htm"
     expect(@story.link).to eq(link)
   end
 
-  it 'returns the title' do
-    title = 'Broken lives of Fukushima'
+  it "returns the title" do
+    title = "Broken lives of Fukushima"
     expect(@story.title).to eq(title)
   end
 
-  it 'returns the authors' do
-    authors = 'The Big Picture'
+  it "returns the authors" do
+    authors = "The Big Picture"
     expect(@story.authors).to eq(authors)
   end
 
-  it 'returns the hash' do
-    hash = '1095:67324d'
+  it "returns the hash" do
+    hash = "1095:67324d"
     expect(@story.hash).to eq(hash)
   end
 
-  it 'returns the published_at' do
-    published_at = '2013-10-07 23:54:16'
+  it "returns the published_at" do
+    published_at = "2013-10-07 23:54:16"
     expect(@story.published_at).to eq(DateTime.parse(published_at))
   end
 
-  it 'returns the tags' do
-    tags = %w('Fukushima', 'Japan', 'tsunami')
+  it "returns the tags" do
+    tags = %w("Fukushima", "Japan", "tsunami")
     expect(@story.tags).to eq(tags)
   end
 
-  it 'returns the content' do
-    content = 'In 2011 a massive earthquake and tsunami wrecked the ' \
-              'Fukushima nuclear plant, resulting in a meltdown that ' \
-              'became the world\'s worst atomic crisis in 25 years.'
+  it "returns the content" do
+    content = "In 2011 a massive earthquake and tsunami wrecked the " \
+              "Fukushima nuclear plant, resulting in a meltdown that " \
+              "became the world\"s worst atomic crisis in 25 years."
     expect(@story.content).to eq(content)
   end
 
-  it 'returns the feed_title' do
-    feed_title = 'The Big Picture'
+  it "returns the feed_title" do
+    feed_title = "The Big Picture"
     expect(@story.feed_title).to eq(feed_title)
   end
 
-  it 'returns the feed_link' do
-    feed_link = 'http://boston.com'
+  it "returns the feed_link" do
+    feed_link = "http://boston.com"
     expect(@story.feed_link).to eq(feed_link)
   end
 
-  it 'returns the feed_address' do
-    feed_address = 'http://feeds.boston.com'
+  it "returns the feed_address" do
+    feed_address = "http://feeds.boston.com"
     expect(@story.feed_address).to eq(feed_address)
   end
 end

--- a/spec/newsblurry/version_spec.rb
+++ b/spec/newsblurry/version_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Newsblurry do
-  it 'returns the version' do
-    expect(Newsblurry::VERSION).to eq('1.0.0')
+  it "returns the version" do
+    expect(Newsblurry::VERSION).to eq("1.0.0")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
-require File.expand_path(File.dirname(__FILE__) + '/../lib/newsblurry')
+require File.expand_path(File.dirname(__FILE__) + "/../lib/newsblurry")
 
-require 'pry'
-require 'webmock/rspec'
+require "pry"
+require "webmock/rspec"
 
 WebMock.disable_net_connect!
 


### PR DESCRIPTION
This is just a bunch of simple fixes to resolve all the existing Rubocop offenses (and fix a syntax error in the `.rubocop.yml` file).