### PR TITLE
Remove pry from Gemfile to resolve duplicate gem error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source "https://rubygems.org/"
 
 gemspec
 
-gem "pry"
 gem "rspec"
 gem "rake"


### PR DESCRIPTION
Pry is listed as a development dependency in `newsblurry.gemspec` and also included in the `Gemfile`, so Bundler gives the following warning:

```
Your Gemfile lists the gem pry (>= 0) more than once.
You should probably keep only one of them.
```

If pry is just a development dependency then it's probably safe to remove it from the Gemfile, yes?
